### PR TITLE
Add Impact and Effort fields

### DIFF
--- a/containers/projectContainer.py
+++ b/containers/projectContainer.py
@@ -26,6 +26,8 @@ class ProjectContainer(ConceptContainer):
             "TimeRequired": 0,
             "StartDate": None,
             "EndDate": None,
+            "Impact": 0.0,
+            "Effort": 0.0,
         }
     )
 

--- a/handlers/flask_mixins/container_crud_mixin.py
+++ b/handlers/flask_mixins/container_crud_mixin.py
@@ -87,7 +87,7 @@ class ContainerCRUDMixin:
             for key, value in container.items():
                 if key == "StartDate" or key == "EndDate":
                     value = target_container.parse_date_auto(value)
-                elif key == "TimeRequired":
+                elif key in ("TimeRequired", "Impact", "Effort"):
                     if value:
                         value = float(value)
                 elif key == "Tags":

--- a/handlers/flask_mixins/container_serialization_mixin.py
+++ b/handlers/flask_mixins/container_serialization_mixin.py
@@ -38,6 +38,8 @@ class ContainerSerializationMixin:
 
             TimeRequired = container.getValue("TimeRequired")
             Horizon = container.getValue("Horizon")
+            Impact = container.getValue("Impact")
+            Effort = container.getValue("Effort")
             tags = container.getValue("Tags") or []
             tags = ",".join(tags)
 
@@ -51,6 +53,8 @@ class ContainerSerializationMixin:
                     "EndDate": EndDate,
                     "TimeRequired": TimeRequired,
                     "Horizon": Horizon,
+                    "Impact": Impact,
+                    "Effort": Effort,
                 }
             )
         return export


### PR DESCRIPTION
## Summary
- expand `ProjectContainer` defaults to include `Impact` and `Effort`
- parse numeric impact/effort values when writing back containers
- expose impact and effort through container serialization

## Testing
- `python -m py_compile containers/projectContainer.py handlers/flask_mixins/container_crud_mixin.py handlers/flask_mixins/container_serialization_mixin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866338a8ba48325b1b8b647df200a72