### PR TITLE
Use deepcopy for container values

### DIFF
--- a/container_base/baseTools.py
+++ b/container_base/baseTools.py
@@ -15,7 +15,7 @@ class baseTools:
     def __init__(self):
         # Set default values
         self.containers = []
-        self.values = self.class_values.copy()
+        self.values = copy.deepcopy(self.class_values)
 
         # Generate id as a has of current time
         self.assign_id()


### PR DESCRIPTION
## Summary
- avoid shared state across container instances by deep copying `class_values` in `baseTools`

## Testing
- `python -m py_compile container_base/baseTools.py`


------
https://chatgpt.com/codex/tasks/task_e_689102f762e88325be2a5e56615974b7