### PR TITLE
Add join_similar OpenAI action for merged container creation

### DIFF
--- a/containers/baseContainer.py
+++ b/containers/baseContainer.py
@@ -353,6 +353,11 @@ class ConceptContainer(Container, StateTools):
 
         return joined_container
 
+    @classmethod
+    def joinContainers(cls, containers):
+        """Alias for join_containers to maintain backwards compatibility."""
+        return cls.join_containers(containers)
+
     def add_parent(self, parent, sibling):
         """
         Add a parent to this container, ensuring no duplicates.


### PR DESCRIPTION
## Summary
- add `join_similar` endpoint to merge similar containers into one using `joinContainers`
- provide `joinContainers` alias for `join_containers` in `ConceptContainer`

## Testing
- `python -m py_compile handlers/flask_mixins/container_ai_mixin.py containers/baseContainer.py`


------
https://chatgpt.com/codex/tasks/task_e_689d9364354c832588934740d2bab589