### PR TITLE
feat: add node search repository method

### DIFF
--- a/handlers/mongodb_handler.py
+++ b/handlers/mongodb_handler.py
@@ -89,6 +89,14 @@ class MongoContainerRepository(ContainerRepository):
         # refresh
         return inst
 
+    def search_nodes(self, search_term: str) -> List[Dict[str, Any]]:
+        """Return nodes matching the search term with their id and Name."""
+        cursor = self.NODES.find(
+            {"values.Name": {"$regex": search_term, "$options": "i"}},
+            {"_id": 1, "values.Name": 1},
+        )
+        return [{"id": doc["_id"], "Name": doc.get("values", {}).get("Name")} for doc in cursor]
+
     def list_project_names(self) -> List[str]:
         return list(self.COLL.distinct("name"))
 

--- a/handlers/repository_handler.py
+++ b/handlers/repository_handler.py
@@ -10,6 +10,11 @@ class ContainerRepository(ABC):
     """Abstract interface for persisting ConceptContainer instances."""
 
     @abstractmethod
+    def search_nodes(self, search_term: str) -> List[Dict[str, Any]]:
+        """Search nodes by a case-insensitive term and return id and Name fields."""
+        pass
+
+    @abstractmethod
     def list_project_names(self) -> List[str]:
         """Return a list of all project names."""
         pass


### PR DESCRIPTION
## Summary
- add search_nodes abstraction to repository interface
- implement MongoDB search_nodes to fetch matching node ids and names

## Testing
- `python -m py_compile handlers/repository_handler.py handlers/mongodb_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68a425d4fc8883259c4f33d7665a963e