### PR TITLE
feat: export OneNote content using CF_HTML

### DIFF
--- a/containers/conceptContainer.py
+++ b/containers/conceptContainer.py
@@ -176,7 +176,7 @@ class ConceptContainer(BaseContainer, StateTools):
 
     def get_onenote(self):
         html = self.create_rtf()
-        return html.get_simple_rtf()
+        return html.get_cf_html()
 
     def rename_from_description(self):
         description = self.getValue("Description")


### PR DESCRIPTION
## Summary
- generate Windows CF_HTML content for HTMLDocument
- support copying CF_HTML to clipboard and returning it from get_onenote

## Testing
- `python -m py_compile handlers/rtf_handler.py containers/conceptContainer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c069e56da08325854acebe83050db3